### PR TITLE
Add call to find_library

### DIFF
--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -62,7 +62,7 @@ if (JLIBNAME == Path()):
 if (JLIBNAME == Path()):
 #---------------------------- search machine path for binary
     if   (platform.system() == WIN):
-        JLIBNAME = ctypes.util.find_library("jigsaw.dll")
+        JLIBNAME = Path(ctypes.util.find_library("jigsaw.dll"))
 
     elif (platform.system() == LNX):
         JLIBNAME = Path("libjigsaw.so")

--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -1,5 +1,6 @@
 
 import ctypes as ct
+import ctypes.util
 import numpy as np
 import inspect
 import platform
@@ -61,7 +62,7 @@ if (JLIBNAME == Path()):
 if (JLIBNAME == Path()):
 #---------------------------- search machine path for binary
     if   (platform.system() == WIN):
-        JLIBNAME = Path("jigsaw.dll")
+        JLIBNAME = ctypes.util.find_library("jigsaw.dll")
 
     elif (platform.system() == LNX):
         JLIBNAME = Path("libjigsaw.so")


### PR DESCRIPTION
This helps Windows find `jigsaw.dll` without a full path name.

A similar call seems not to be needed for Linux and not to work for OSX.

I created a patch identical to this in the conda-forge recipe:
https://github.com/conda-forge/staged-recipes/pull/10842/commits/b8d1bc4d9cffadf1c8ca62069d5f6e676cc271e4