### PR TITLE
Find shared library on PYTHONPATH if otherwise not found in system

### DIFF
--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -73,16 +73,15 @@ if (JLIBNAME == Path()):
 
 if not JLIBNAME.is_file():
     # Search for libjigsaw on lib directory of current Python environment
-    libdir = Path("/".join(sys.executable.split('/')[:-2])) / 'lib'
-    JLIBNAME = libdir.resolve()
+    JLIBNAME = Path("/".join(sys.executable.split('/')[:-2])) / 'lib'
     if platform.system() == WIN:
-        JLIBNAME /= Path(ctypes.util.find_library("jigsaw.dll"))
+        JLIBNAME /= ctypes.util.find_library("jigsaw.dll")
 
     elif platform.system() == LNX:
-        JLIBNAME /= Path("libjigsaw.so")
+        JLIBNAME /= "libjigsaw.so"
 
     elif platform.system() == MAC:
-        JLIBNAME /= Path("libjigsaw.dylib")
+        JLIBNAME /= "libjigsaw.dylib"
 
 if JLIBNAME.is_file():
 #---------------------------- load jigsaw library via ctypes

--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -4,6 +4,7 @@ import ctypes.util
 import numpy as np
 import inspect
 import platform
+import sys
 
 from pathlib import Path
 
@@ -69,6 +70,18 @@ if (JLIBNAME == Path()):
 
     elif (platform.system() == MAC):
         JLIBNAME = Path("libjigsaw.dylib")
+
+if not JLIBNAME.exists():
+    libdir = Path("/".join(sys.executable.split('/')[:-2])) / 'lib'
+    JLIBNAME = libdir.resolve()
+    if platform.system() == WIN:
+        JLIBNAME /= Path(ctypes.util.find_library("jigsaw.dll"))
+
+    elif (platform.system() == LNX):
+        JLIBNAME /= Path("libjigsaw.so")
+
+    elif (platform.system() == MAC):
+        JLIBNAME /= Path("libjigsaw.dylib")
 
 if (JLIBNAME != Path()):
 #---------------------------- load jigsaw library via ctypes

--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -71,7 +71,7 @@ if (JLIBNAME == Path()):
     elif (platform.system() == MAC):
         JLIBNAME = Path("libjigsaw.dylib")
 
-if not JLIBNAME.exists():
+if not JLIBNAME.is_file():
     libdir = Path("/".join(sys.executable.split('/')[:-2])) / 'lib'
     JLIBNAME = libdir.resolve()
     if platform.system() == WIN:
@@ -83,7 +83,7 @@ if not JLIBNAME.exists():
     elif (platform.system() == MAC):
         JLIBNAME /= Path("libjigsaw.dylib")
 
-if (JLIBNAME != Path()):
+if JLIBNAME.is_file():
 #---------------------------- load jigsaw library via ctypes
     JLIB = ct.cdll.LoadLibrary(str(JLIBNAME))
 

--- a/jigsawpy/libsaw.py
+++ b/jigsawpy/libsaw.py
@@ -72,15 +72,16 @@ if (JLIBNAME == Path()):
         JLIBNAME = Path("libjigsaw.dylib")
 
 if not JLIBNAME.is_file():
+    # Search for libjigsaw on lib directory of current Python environment
     libdir = Path("/".join(sys.executable.split('/')[:-2])) / 'lib'
     JLIBNAME = libdir.resolve()
     if platform.system() == WIN:
         JLIBNAME /= Path(ctypes.util.find_library("jigsaw.dll"))
 
-    elif (platform.system() == LNX):
+    elif platform.system() == LNX:
         JLIBNAME /= Path("libjigsaw.so")
 
-    elif (platform.system() == MAC):
+    elif platform.system() == MAC:
         JLIBNAME /= Path("libjigsaw.dylib")
 
 if JLIBNAME.is_file():


### PR DESCRIPTION
This is so that libjigsaw.* can be picked up from PYTHONPATH if all other places fail.