### PR TITLE
Fix `np.unique()` calls for numpy 2.0

### DIFF
--- a/jigsawpy/bisect.py
+++ b/jigsawpy/bisect.py
@@ -208,6 +208,9 @@ def bisect(mesh):
             return_index=True,
             return_inverse=True, axis=0)
 
+        # for numpy 2.x compatibility
+        erev = erev.ravel()
+
         edge = edge[efwd, :]
 
     if (quad.size != 0):
@@ -216,6 +219,9 @@ def bisect(mesh):
             return_index=True,
             return_inverse=True, axis=0)
 
+        # for numpy 2.x compatibility
+        qrev = qrev.ravel()
+
         quad = quad[qfwd, :]
 
     if (hexa.size != 0):
@@ -223,6 +229,9 @@ def bisect(mesh):
             np.sort(hexa, axis=+1),
             return_index=True,
             return_inverse=True, axis=0)
+
+        # for numpy 2.x compatibility
+        hrev = hrev.ravel()
 
         hexa = hexa[hfwd, :]
 


### PR DESCRIPTION
Numpy now returns a 2D array for reverse indexing, but we want the flattened version.

fixes #26 